### PR TITLE
Fix linux crash

### DIFF
--- a/src/ProjectionView.h
+++ b/src/ProjectionView.h
@@ -82,14 +82,14 @@ protected:
 
 private:
     PointRenderer   _pointRenderer;
-    Bounds          _dataBounds;             /** Bounds of the loaded data */
-    QSize           _windowSize;             /** Size of the scatterplot widget */
+    Bounds          _dataBounds = {};             /** Bounds of the loaded data */
+    QSize           _windowSize = {};             /** Size of the scatterplot widget */
 
-    QString         _projectionName;
+    QString         _projectionName = {};
 
-    QImage          _colorMapImage;
+    QImage          _colorMapImage = {};
 
-    Vector2f        _currentPoint;
+    Vector2f        _currentPoint = {};
 
     bool            _isInitialized = false;
 

--- a/src/SpaceWalkerPlugin.cpp
+++ b/src/SpaceWalkerPlugin.cpp
@@ -87,7 +87,6 @@ SpaceWalkerPlugin::SpaceWalkerPlugin(const PluginFactory* factory) :
     _positionSourceDataset(),
     _numPoints(0),
     _primaryToolbarAction(this, "PrimaryToolbar"),
-    _secondaryToolbarAction(this, "SecondaryToolbar"),
     _scatterPlotWidget(new ScatterplotWidget()),
     _projectionViews(2, nullptr),
     _selectedView(),

--- a/src/SpaceWalkerPlugin.cpp
+++ b/src/SpaceWalkerPlugin.cpp
@@ -277,7 +277,6 @@ void SpaceWalkerPlugin::init()
 {
     auto layout = new QVBoxLayout();
     auto gradientViewLayout = new QVBoxLayout();
-    auto dimensionViewsLayout = new QHBoxLayout();
 
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);

--- a/src/SpaceWalkerPlugin.cpp
+++ b/src/SpaceWalkerPlugin.cpp
@@ -276,18 +276,16 @@ SpaceWalkerPlugin::~SpaceWalkerPlugin()
 void SpaceWalkerPlugin::init()
 {
     auto layout = new QVBoxLayout();
-    auto gradientViewLayout = new QVBoxLayout();
-
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
-    layout->addWidget(_primaryToolbarAction.createWidget(&getWidget()));
 
-    _filterLabel = new QLabel();
-    _filterLabel->setText("Spatial Peak Ranking");
+    _filterLabel = new QLabel("Spatial Peak Ranking");
     QFont font = _filterLabel->font();
     font.setPointSize(font.pointSize() * 2);
     _filterLabel->setFont(font);
 
+    // Central layout
+    auto gradientViewLayout = new QVBoxLayout();
     gradientViewLayout->setContentsMargins(6, 0, 6, 0);
     gradientViewLayout->addWidget(_filterLabel);
     gradientViewLayout->addWidget(_projectionViews[0], 50);
@@ -306,13 +304,17 @@ void SpaceWalkerPlugin::init()
     gradientViewLayout->addWidget(_graphView, 70);
 
     auto leftPanel = new QVBoxLayout();
-    leftPanel->addWidget(_scatterPlotWidget, 90);
+    leftPanel->addWidget(_scatterPlotWidget, 100);
 
-    auto centralPanel = new QHBoxLayout();
-    centralPanel->addLayout(leftPanel, 80);
-    centralPanel->addLayout(gradientViewLayout, 20);
+    auto centralPanelWidget = new QWidget();
+    auto centralPanelLayout = new QHBoxLayout();
 
-    layout->addLayout(centralPanel, 100);
+    centralPanelLayout->setContentsMargins(0, 0, 0, 0);
+
+    centralPanelLayout->addLayout(leftPanel, 100);
+    centralPanelLayout->addLayout(gradientViewLayout, 20);
+
+    centralPanelWidget->setLayout(centralPanelLayout);
 
     auto bottomToolbarWidget = new QWidget();
     auto bottomToolbarLayout = new QHBoxLayout();
@@ -328,7 +330,8 @@ void SpaceWalkerPlugin::init()
     //bottomToolbarLayout->addWidget(_settingsAction.getExportImageAction().createWidget(&getWidget()));
     bottomToolbarLayout->addWidget(_settingsAction.getMiscellaneousAction().createCollapsedWidget(&getWidget()));
 
-    layout->addWidget(_secondaryToolbarAction.createWidget(&getWidget()));
+    layout->addWidget(_primaryToolbarAction.createWidget(&getWidget()));
+    layout->addWidget(centralPanelWidget, 100);
 
     getWidget().setLayout(layout);
 

--- a/src/SpaceWalkerPlugin.cpp
+++ b/src/SpaceWalkerPlugin.cpp
@@ -112,8 +112,8 @@ SpaceWalkerPlugin::SpaceWalkerPlugin(const PluginFactory* factory) :
     _primaryToolbarAction.addAction(&_settingsAction.getFilterAction(), 0, GroupAction::Horizontal);
     _primaryToolbarAction.addAction(&_settingsAction.getOverlayAction(), 0, GroupAction::Horizontal);
     _primaryToolbarAction.addAction(&_settingsAction.getExportAction(), 0, GroupAction::Horizontal);
-    _primaryToolbarAction.addAction(&_settingsAction.getSelectionAsMaskAction());
-    _primaryToolbarAction.addAction(&_settingsAction.getClearMaskAction());
+    _primaryToolbarAction.addAction(&_settingsAction.getSelectionAsMaskAction(), 0, GroupAction::Horizontal);
+    _primaryToolbarAction.addAction(&_settingsAction.getClearMaskAction(), 0, GroupAction::Horizontal);
 
     _dropWidget = new DropWidget(_scatterPlotWidget);
 

--- a/src/SpaceWalkerPlugin.cpp
+++ b/src/SpaceWalkerPlugin.cpp
@@ -332,6 +332,7 @@ void SpaceWalkerPlugin::init()
 
     layout->addWidget(_primaryToolbarAction.createWidget(&getWidget()));
     layout->addWidget(centralPanelWidget, 100);
+    //layout->addWidget(bottomToolbarWidget);
 
     getWidget().setLayout(layout);
 

--- a/src/SpaceWalkerPlugin.cpp
+++ b/src/SpaceWalkerPlugin.cpp
@@ -304,14 +304,14 @@ void SpaceWalkerPlugin::init()
     gradientViewLayout->addWidget(_graphView, 70);
 
     auto leftPanel = new QVBoxLayout();
-    leftPanel->addWidget(_scatterPlotWidget, 100);
+    leftPanel->addWidget(_scatterPlotWidget, 90);
 
     auto centralPanelWidget = new QWidget();
     auto centralPanelLayout = new QHBoxLayout();
 
     centralPanelLayout->setContentsMargins(0, 0, 0, 0);
 
-    centralPanelLayout->addLayout(leftPanel, 100);
+    centralPanelLayout->addLayout(leftPanel, 80);
     centralPanelLayout->addLayout(gradientViewLayout, 20);
 
     centralPanelWidget->setLayout(centralPanelLayout);

--- a/src/SpaceWalkerPlugin.h
+++ b/src/SpaceWalkerPlugin.h
@@ -267,7 +267,6 @@ protected:
     SettingsAction              _settingsAction;
     ColorMap1DAction            _colorMapAction;            /** Color map action */
     HorizontalToolbarAction     _primaryToolbarAction;      /** Horizontal toolbar for primary content */
-    HorizontalToolbarAction     _secondaryToolbarAction;    /** Secondary toolbar for secondary content */
 };
 
 // =============================================================================


### PR DESCRIPTION
I'm not entirely sure why, but adding some `_primaryToolbarAction.addAction` with and some without defining `autoExpandPriority` and `widgetFlags` explicitly leads to a crash on linux.

The other changes are mainly cosmetic.